### PR TITLE
Places system prompt in the correct location.

### DIFF
--- a/backend/chat_playground/services.py
+++ b/backend/chat_playground/services.py
@@ -16,7 +16,7 @@ def invoke(prompt):
                    """;
 
     prompt_config = {
-        "prompt": f'\n\nHuman: {systemPrompt}\n\n{prompt}\n\nAssistant:',
+        "prompt": f'{systemPrompt}\n\nHuman: {prompt}\n\nAssistant:',
         "max_tokens_to_sample": 1024,
         "temperature": 0.8
     }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* According to [the docs](https://docs.anthropic.com/claude/docs/how-to-use-system-prompts#legacy-system-prompts-via-text-completions-api) for Claude v2, using the Text Completion end-point, the system prompt should appear immediately **before** the Human prompt. 

This PR shifts it over to the proper place. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
