### PR TITLE
Switch Chat and text modules to Claude3

### DIFF
--- a/backend/chat_playground/routes.py
+++ b/backend/chat_playground/routes.py
@@ -1,7 +1,13 @@
+import sys
+sys.path.append("../fm")
+
+
 from fastapi import APIRouter, HTTPException
 from botocore.exceptions import ClientError
 from . import models
 from . import services
+
+from fm import claude3
 
 router = APIRouter()
 
@@ -10,6 +16,19 @@ router = APIRouter()
 def invoke(body: models.ChatRequest):
     try:
         completion = services.invoke(body.prompt)
+        return models.ChatResponse(
+            completion=completion
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "AccessDeniedException":
+            raise HTTPException(status_code=403)
+        else:
+            raise HTTPException(status_code=500)
+
+@router.post("/foundation-models/model/chat/anthropic.claude-v3/invoke")
+def invoke(body: models.ChatRequest):
+    try:
+        completion = claude3.invoke(body.prompt)
         return models.ChatResponse(
             completion=completion
         )

--- a/backend/fm/claude3.py
+++ b/backend/fm/claude3.py
@@ -1,0 +1,35 @@
+import boto3
+import json
+
+bedrock_runtime = boto3.client(
+    service_name="bedrock-runtime",
+    region_name="us-east-1",
+)
+
+def invoke(prompt, temp=0.5,  max_tokens=1024):
+    systemPrompt = """
+                    Always Verify your technical answer or say it if you are not sure. Use AWs documentation as reference
+                   """;
+
+    prompt_config = {
+        "max_tokens": max_tokens,
+        "temperature": temp,
+        "anthropic_version": "bedrock-2023-05-31",
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": f'{systemPrompt}\n\n{prompt}'}],
+            }
+        ],
+    }
+    model_id = "anthropic.claude-3-sonnet-20240229-v1:0"
+
+    response = bedrock_runtime.invoke_model(
+        body=json.dumps(prompt_config),
+        modelId=model_id
+    )
+
+    response_body = json.loads(response.get("body").read())
+
+
+    return response_body["content"][0]["text"]

--- a/backend/text_playground/routes.py
+++ b/backend/text_playground/routes.py
@@ -1,8 +1,14 @@
+import sys
+sys.path.append("../fm")
+
 from fastapi import APIRouter, HTTPException
 from botocore.exceptions import ClientError
 from . import models
 from . import claude
 from . import jurassic2
+
+from fm import claude3
+
 
 
 router = APIRouter()
@@ -12,6 +18,8 @@ def invoke(body: models.TextRequest, modelId: str):
     try:
         if modelId == "anthropic.claude-v2":
             completion = claude.invoke(body.prompt, body.temperature, body.maxTokens)
+        if modelId == "anthropic.claude-3-sonnet-20240229-v1:0":
+            completion = claude3.invoke(body.prompt, body.temperature, body.maxTokens)
         elif modelId == "ai21.j2-mid-v1":
             completion = jurassic2.invoke(body.prompt, body.temperature, body.maxTokens)
 

--- a/frontend/components/chatPlayground/ChatComponent.jsx
+++ b/frontend/components/chatPlayground/ChatComponent.jsx
@@ -12,7 +12,8 @@ export default function ChatContainer() {
     const [inputValue, setInputValue] = useState("");
     const [isLoading, setIsLoading] = useState(false);
 
-    const endpoint = "/foundation-models/model/chat/anthropic.claude-v2/invoke";
+    //const endpoint = "/foundation-models/model/chat/anthropic.claude-v2/invoke";
+    const endpoint = "/foundation-models/model/chat/anthropic.claude-v3/invoke";
     const api = `${GlobalConfig.apiHost}:${GlobalConfig.apiPort}${endpoint}`;
 
     const handleInputChange = (e) => {
@@ -65,7 +66,7 @@ export default function ChatContainer() {
     return <div className="flex flex-col flex-auto h-full p-6">
         <h3 className="text-3xl font-medium text-gray-700">Chat Playground</h3>
         <div className="flex flex-col flex-auto flex-shrink-0 rounded-2xl bg-gray-100 p-4 mt-8">
-            <ModelIndicator modelName="Anthropic Claude 2" />
+            <ModelIndicator modelName="Anthropic Claude 3" />
             <div className="flex flex-col h-full overflow-x-auto mb-4">
                 <div className="flex flex-col h-full">
                     <div className="grid grid-cols-12 gap-y-2">

--- a/frontend/helpers/modelData.js
+++ b/frontend/helpers/modelData.js
@@ -28,6 +28,20 @@ export const models = [
             max: 8191,
             default: 200
         }
+    },
+    {
+        modelName: "Anthropic Claude 3",
+        modelId: "anthropic.claude-3-sonnet-20240229-v1:0",
+        temperatureRange: {
+            min: 0,
+            max: 1,
+            default: 0.5
+        },
+        maxTokenRange: {
+            min: 0,
+            max: 4096,
+            default: 1024
+        }
     }
 ]
 


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes: Use Claude 3 Sonnet in chat

This pull request introduces a change to the underlying  model used in the chat module by claude3  and add this same model to the list of available models  in text module.

Key changes include:

Replacing claude2 with claude3 in chat module
Updating relevant configurations and dependencies to support the new model fort text and chat modules
Performing initial tests to validate the new model's integration.
Proposal to use common functions for chat and text.

Please review and provide feedback. 
If interested by contribution, I have already add nova. Thank you!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
